### PR TITLE
Disable useless things

### DIFF
--- a/data/ui_scripts/patches/__init__.lua
+++ b/data/ui_scripts/patches/__init__.lua
@@ -6,6 +6,7 @@ if (Engine.InFrontend()) then
 	require("shaderdialog")
 	require("gamemodes")
 	require("no_mode_switch")
+	require("disable_useless_things")
 end
 
 -- defined in mp_hud/hudutils.lua

--- a/data/ui_scripts/patches/disable_useless_things.lua
+++ b/data/ui_scripts/patches/disable_useless_things.lua
@@ -1,0 +1,17 @@
+-- Disable CP
+Engine.SetDvarInt("ui_enable_cp", 0)
+
+-- Disable CP store
+Engine.SetDvarInt("ui_show_store", 0)
+
+-- Remove CoD account button
+if Engine.IsMultiplayer() then
+    LUI.removemenubutton("pc_controls", 4)
+end
+
+-- Remove social button
+LUI.MenuBuilder.m_definitions["online_friends_widget"] = function()
+    return {
+        type = "UIElement"
+    }
+end

--- a/src/client/resources/ui_scripts/common.lua
+++ b/src/client/resources/ui_scripts/common.lua
@@ -147,6 +147,24 @@ LUI.addmenubutton = function(name, data)
 	end)
 end
 
+LUI.removemenubutton = function(name, index)
+    LUI.onmenuopen(name, function(menu)
+        if (not menu.list) then
+            return
+        end
+
+        local buttonlist = menu:getChildById(menu.type .. "_list")
+        local button = buttonlist.childRecord[string.format("%s_button_%s", name, index)]
+        buttonlist:removeElement(button)
+
+        local hintbox = menu.optionTextInfo
+        menu:removeElement(hintbox)
+
+        LUI.Options.InitScrollingList(menu.list, nil)
+        menu.optionTextInfo = LUI.Options.AddOptionTextInfo(menu)
+    end)
+end
+
 LUI.openmenu = function(menu, args)
 	stack = args
 	LUI.FlowManager.RequestAddMenu(nil, menu)


### PR DESCRIPTION
It disable CP and CP store, remove CoD account in options menu and social button since it's not working atm.
Adding ``LUI.removemenubutton`` too, it can be may be useful ?
Thanks to @VladWinner to have found the CP & CP store dvar.